### PR TITLE
Refactoring

### DIFF
--- a/src/main/java/retrieval/BM25.java
+++ b/src/main/java/retrieval/BM25.java
@@ -28,7 +28,7 @@ public class BM25 extends Models {
         return (ArrayList<Similarity>) scoredDocuments.entrySet().stream()
             .map(entry -> new Similarity(entry.getKey(), entry.getValue()))
             .sorted(Comparator.reverseOrder())
-            .limit(Models.DOCUMENTSRETURNED)
+            .limit(RESULT_SET_SIZE)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/retrieval/LDA.java
+++ b/src/main/java/retrieval/LDA.java
@@ -7,25 +7,6 @@ public class LDA extends Models {
         super();
     }
 
-    private static double termFrequency(String term, String document) {
-        int totalTerms = getFileTermSize().get(document);
-        int occurrences = get_doc_indicies().get(term).getFileOccurrences().stream()
-                .filter(e -> e.getFilename().equals(document)).findFirst().orElse(new FileOccurrence("", 0))
-                .getOccurrences();
-
-        return (double) occurrences / totalTerms;
-    }
-
-    private static double inverseDocumentFrequency(String term) {
-        int totalDocuments = fileTermSize.keySet().size();
-        int documentsWithTerm = documents.get(term).getSize();
-        return Math.log((double) totalDocuments / documentsWithTerm);
-    }
-
-    public static double tfidf(String term, String document) {
-        return occursInDocuments(term) ? termFrequency(term, document) * inverseDocumentFrequency(term) : 0;
-    }
-
     public ArrayList<Similarity> retrieve(String query) {
         
         return null;

--- a/src/main/java/retrieval/Models.java
+++ b/src/main/java/retrieval/Models.java
@@ -8,23 +8,56 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 abstract public class Models {
-    private static final String indicies_path = Index.output_dir;
+    static final int DOCUMENTSRETURNED = 30;
+    public static final HashMap<String, String> HTMLDOCPATHS = parseDocNumMap();
+    private static final String INDICIES_PATH = Index.output_dir;
     private static final String FILE_TERM_SIZE_PATH = Index.docSize;
     private static final String DOCNUMMAPPATH = "indicies/doc-num-map.tsv";
-    static final HashMap<String, Integer> fileTermSize = parseDocumentIndexFile(FILE_TERM_SIZE_PATH);
-    static final HashMap<String, Entry> documents = parse_doc_indicies();
-    public static final HashMap<String, String> HTMLDOCPATHS = parseDocNumMap();
-    static final int DOCUMENTSRETURNED = 30;
-    static final Map<String, Map<String, Integer>> termToFileAndOccurrence = createIndexMap();
+    private static final HashMap<String, Integer> FILE_TERM_SIZE = parseDocumentIndexFile(FILE_TERM_SIZE_PATH);
+    private static final HashMap<String, Entry> TOKEN_TO_ENTRY = parseTokenIndexFile();
+    private static final Map<String, Map<String, Integer>> TERM_TO_FILE_AND_OCCURRENCE = collapseIndexIntoMaps();
 
     Models() {}
+
+    public abstract ArrayList<Similarity> retrieve(String query);
+
+    static double tfidf(String term, String document) {
+        return occursInDocuments(term) ? termFrequency(term, document) * inverseDocumentFrequency(term) : 0;
+    }
+
+    static Set<String> getAllDocuments() {
+//        ArrayList<String> documents = new ArrayList<>();
+//        for (File f : Objects.requireNonNull(new File(Index.docs_file_path).listFiles())) {
+//            documents.add(f.getName());
+//        }
+//        return documents;
+
+        return FILE_TERM_SIZE.keySet();
+    }
+
+    static HashMap<String, Integer> getFileTermSize() {
+        return FILE_TERM_SIZE;
+    }
+
+    static HashMap<String, Entry> getTokenToEntryIndex() {
+        return TOKEN_TO_ENTRY;
+    }
+
+    static boolean occursInDocuments(String term) {
+        return TOKEN_TO_ENTRY.containsKey(term);
+    }
+
+    int getOccurrencesInFile(String term, String filename) {
+        return TERM_TO_FILE_AND_OCCURRENCE.getOrDefault(term, new HashMap<>()).getOrDefault(filename, 0);
+    }
+
+    static String[] extractTerms(String query) {
+        return query.toLowerCase().split("\\s+");
+    }
 
     private static HashMap<String, Integer> parseDocumentIndexFile(String path) {
         HashMap<String, Integer> docMap = new HashMap<>();
@@ -32,7 +65,7 @@ abstract public class Models {
 
         try {
             Files.readLines(index, Charset.defaultCharset())
-                    .forEach(entry -> docMap.put(entry.split("\t")[0], Integer.parseInt(entry.split("\t")[1])));
+                .forEach(entry -> docMap.put(entry.split("\t")[0], Integer.parseInt(entry.split("\t")[1])));
         } catch (IOException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
@@ -40,32 +73,10 @@ abstract public class Models {
         return docMap;
     }
 
-    ArrayList<String> getDocumentList() {
-        ArrayList<String> documents = new ArrayList<>();
-        for (File f : Objects.requireNonNull(new File(Index.docs_file_path).listFiles())) {
-            documents.add(f.getName());
-        }
-        return documents;
-    }
-
-    public static HashMap<String, Entry> get_doc_indicies() {
-        return documents;
-    }
-
-    public static boolean occursInDocuments(String term) {
-        return get_doc_indicies().containsKey(term);
-    }
-
-    public abstract ArrayList<Similarity> retrieve(String query);
-
-    String[] extractTerms(String query) {
-        return query.toLowerCase().split("\\s+");
-    }
-
-    private static HashMap<String, Entry> parse_doc_indicies() {
+    private static HashMap<String, Entry> parseTokenIndexFile() {
         try {
             HashMap<String, Entry> terms = new HashMap<>();
-            File index = new File(indicies_path);
+            File index = new File(INDICIES_PATH);
             BufferedReader br = new BufferedReader(new FileReader(index));
             String line;
 
@@ -107,8 +118,8 @@ abstract public class Models {
         return siMap;
     }
 
-    private static Map<String, Map<String, Integer>> createIndexMap() {
-        return documents.entrySet().stream()
+    private static Map<String, Map<String, Integer>> collapseIndexIntoMaps() {
+        return TOKEN_TO_ENTRY.entrySet().stream()
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 entry -> convertToMap(entry.getValue())));
@@ -121,12 +132,19 @@ abstract public class Models {
                 FileOccurrence::getOccurrences));
     }
 
-    public static HashMap<String, Integer> getFileTermSize() {
-        return fileTermSize;
+    private static double termFrequency(String term, String document) {
+        int totalTerms = getFileTermSize().get(document);
+        int occurrences = getTokenToEntryIndex().get(term).getFileOccurrences().stream()
+            .filter(e -> e.getFilename().equals(document)).findFirst().orElse(new FileOccurrence("", 0))
+            .getOccurrences();
+
+        return (double) occurrences / totalTerms;
     }
 
-    public int getOccurrencesInFile(String term, String filename) {
-        return termToFileAndOccurrence.getOrDefault(term, new HashMap<>()).getOrDefault(filename, 0);
+    private static double inverseDocumentFrequency(String term) {
+        int totalDocuments = getFileTermSize().keySet().size();
+        int documentsWithTerm = getTokenToEntryIndex().get(term).getSize();
+        return Math.log((double) totalDocuments / documentsWithTerm);
     }
 
     static class Entry {
@@ -138,7 +156,6 @@ abstract public class Models {
             this.fileOccurrences = fileOccurrences;
         }
 
-
         public int getSize() {
             return size;
         }
@@ -147,12 +164,8 @@ abstract public class Models {
             this.size = size;
         }
 
-        public ArrayList<FileOccurrence> getFileOccurrences() {
+        ArrayList<FileOccurrence> getFileOccurrences() {
             return fileOccurrences;
-        }
-
-        public void setFileOccurrences(ArrayList<FileOccurrence> fileOccurrences) {
-            this.fileOccurrences = fileOccurrences;
         }
     }
 }

--- a/src/main/java/retrieval/Models.java
+++ b/src/main/java/retrieval/Models.java
@@ -12,10 +12,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 abstract public class Models {
-    static final int DOCUMENTSRETURNED = 30;
+    static final int RESULT_SET_SIZE = 30;
     public static final HashMap<String, String> HTMLDOCPATHS = parseDocNumMap();
-    private static final String INDICIES_PATH = Index.output_dir;
-    private static final String FILE_TERM_SIZE_PATH = Index.docSize;
+    private static final String INDICIES_PATH = Index.TOKEN_INDEX_PATH;
+    private static final String FILE_TERM_SIZE_PATH = Index.DOCUMENT_SIZE_PATH;
     private static final String DOCNUMMAPPATH = "indicies/doc-num-map.tsv";
     private static final HashMap<String, Integer> FILE_TERM_SIZE = parseDocumentIndexFile(FILE_TERM_SIZE_PATH);
     private static final HashMap<String, Entry> TOKEN_TO_ENTRY = parseTokenIndexFile();
@@ -31,7 +31,7 @@ abstract public class Models {
 
     static Set<String> getAllDocuments() {
 //        ArrayList<String> documents = new ArrayList<>();
-//        for (File f : Objects.requireNonNull(new File(Index.docs_file_path).listFiles())) {
+//        for (File f : Objects.requireNonNull(new File(Index.DOC_DIRECTORY).listFiles())) {
 //            documents.add(f.getName());
 //        }
 //        return documents;

--- a/src/main/java/retrieval/Pooling.java
+++ b/src/main/java/retrieval/Pooling.java
@@ -4,7 +4,7 @@ import query.QueryController;
 
 import java.util.ArrayList;
 
-import static retrieval.Models.DOCUMENTSRETURNED;
+import static retrieval.Models.RESULT_SET_SIZE;
 
 public class Pooling {
     private Models bm25;
@@ -27,15 +27,15 @@ public class Pooling {
         System.out.println("Retrieving results for model " + this.currModel.toString());
 
         if(this.currModel == QueryController.ModelTypes.LDA) {
-            for(int i = 0; i < DOCUMENTSRETURNED; i++) {
+            for(int i = 0; i < RESULT_SET_SIZE; i++) {
                 returnedResults.add(ldaResults.get(i));
             }
         } else if(this.currModel == QueryController.ModelTypes.BM25) {
-            for(int i = 0; i < DOCUMENTSRETURNED; i++) {
+            for(int i = 0; i < RESULT_SET_SIZE; i++) {
                 returnedResults.add(bm25Results.get(i));
             }
         } else {
-            for (int i = 0; i < DOCUMENTSRETURNED; ) {
+            for (int i = 0; i < RESULT_SET_SIZE; ) {
                 if (i % 2 == 0 && !returnedResults.contains(bm25Results.get(i))) {
                     returnedResults.add(bm25Results.get(i));
                 }


### PR DESCRIPTION
split each index creation into its own method. should help with garbage collection and heap space because each giant index hashmap is separately created.

Also fixed some QOL issues - naming scheme, accessibility of functions, incorrect usage of private fields. 

Moved TFIDF stuff to `Models` because it is static and doesnt belong in LDA